### PR TITLE
metal pixelFormat must be BGRA on macOS 12

### DIFF
--- a/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
@@ -563,9 +563,9 @@ static struct ShaderProgram* gfx_metal_create_and_load_new_shader(uint64_t shade
             if (cc_features.opt_invisible) {
                 append_line(buf, &len, "    texel.w = 0.0;");
             }
-            append_line(buf, &len, "    return texel.bgra;");
+            append_line(buf, &len, "    return texel;");
         } else {
-            append_line(buf, &len, "    return float4(texel, 1.0).bgra;");
+            append_line(buf, &len, "    return float4(texel, 1.0);");
         }
 
         append_line(buf, &len, "}");
@@ -855,7 +855,7 @@ static void gfx_metal_update_framebuffer_parameters(int fb_id, uint32_t width, u
         texDescriptor.height = height;
         texDescriptor.sampleCount = msaa_level;
         texDescriptor.mipmapLevelCount = 1;
-        texDescriptor.pixelFormat = MTLPixelFormatRGBA8Unorm;
+        texDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
         texDescriptor.usage = (render_target ? MTLTextureUsageRenderTarget : 0) | (msaa_level <= 1 ? MTLTextureUsageShaderRead : 0);
 
         tex.texture = [mctx.device newTextureWithDescriptor:texDescriptor];

--- a/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
@@ -587,7 +587,7 @@ static struct ShaderProgram* gfx_metal_create_and_load_new_shader(uint64_t shade
         pipelineDescriptor.fragmentFunction = [library newFunctionWithName:@"fragmentShader"];
         pipelineDescriptor.vertexDescriptor = vertexDescriptor;
 
-        pipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+        pipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
         pipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
         if (cc_features.opt_alpha) {
             pipelineDescriptor.colorAttachments[0].blendingEnabled = YES;

--- a/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_metal.mm
@@ -288,7 +288,7 @@ void Metal_SetRenderer(SDL_Renderer* renderer) {
 
 bool Metal_Init() {
     mctx.layer = (__bridge CAMetalLayer*)SDL_RenderGetMetalLayer(mctx.renderer);
-    mctx.layer.pixelFormat = MTLPixelFormatRGBA8Unorm;
+    mctx.layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 
     mctx.device = mctx.layer.device;
     mctx.command_queue = [mctx.device newCommandQueue];
@@ -563,9 +563,9 @@ static struct ShaderProgram* gfx_metal_create_and_load_new_shader(uint64_t shade
             if (cc_features.opt_invisible) {
                 append_line(buf, &len, "    texel.w = 0.0;");
             }
-            append_line(buf, &len, "    return texel;");
+            append_line(buf, &len, "    return texel.bgra;");
         } else {
-            append_line(buf, &len, "    return float4(texel, 1.0);");
+            append_line(buf, &len, "    return float4(texel, 1.0).bgra;");
         }
 
         append_line(buf, &len, "}");


### PR DESCRIPTION
i believe this shouldn't break anything on macOS 13, but please let me
know!