### PR TITLE
Fix Pacifist mode

### DIFF
--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -672,6 +672,7 @@ static bool PacifistHandler(std::shared_ptr<Ship::Console> Console, const std::v
 
     try {
         pacifistMode = std::stoi(args[1], nullptr, 10) == 0 ? 0 : 1;
+        // Force interface to update to make the buttons transparent
         gSaveContext.unk_13E8 = 50;
         Interface_Update(gGlobalCtx);
         return CMD_SUCCESS;

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -672,6 +672,8 @@ static bool PacifistHandler(std::shared_ptr<Ship::Console> Console, const std::v
 
     try {
         pacifistMode = std::stoi(args[1], nullptr, 10) == 0 ? 0 : 1;
+        gSaveContext.unk_13E8 = 50;
+        Interface_Update(gGlobalCtx);
         return CMD_SUCCESS;
     } catch (std::invalid_argument const& ex) {
         SohImGui::GetConsole()->SendErrorMessage("[SOH] Pacifist value must be a number.");

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -232,10 +232,15 @@ void PadMgr_ProcessInputs(PadMgr* padMgr) {
                 if (noZ) {
                     input->cur.button &= ~(BTN_Z);
                 }
-
-                // Do not block buttons in the pause menu while pacifist mode is enabled
-                if (pacifistMode && gGlobalCtx->pauseCtx.state == 0) {
+                
+                // Do not block buttons in the pause menu, conversations and ocarina play while pacifist mode is
+                // enabled
+                if (pacifistMode && gGlobalCtx->pauseCtx.state == 0 && gGlobalCtx->msgCtx.msgMode == 0) {
                     input->cur.button &= ~(BTN_CLEFT | BTN_CRIGHT | BTN_CUP | BTN_CDOWN | BTN_B);
+
+                    if (CVar_GetS32("gDpadEquips", 0)) {
+                        input->cur.button &= ~(BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
+                    }
                 }
 
                 if (reverseControls) {

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -232,16 +232,6 @@ void PadMgr_ProcessInputs(PadMgr* padMgr) {
                 if (noZ) {
                     input->cur.button &= ~(BTN_Z);
                 }
-                
-                // Do not block buttons in the pause menu, conversations and ocarina play while pacifist mode is
-                // enabled
-                if (pacifistMode && gGlobalCtx->pauseCtx.state == 0 && gGlobalCtx->msgCtx.msgMode == 0) {
-                    input->cur.button &= ~(BTN_CLEFT | BTN_CRIGHT | BTN_CUP | BTN_CDOWN | BTN_B);
-
-                    if (CVar_GetS32("gDpadEquips", 0)) {
-                        input->cur.button &= ~(BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
-                    }
-                }
 
                 if (reverseControls) {
                     if (input->cur.stick_x == -128) {

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -937,7 +937,11 @@ void func_80083108(GlobalContext* globalCtx) {
                 Interface_ChangeAlpha(50);
             }
         } else if (msgCtx->msgMode == MSGMODE_NONE) {
-            if ((func_8008F2F8(globalCtx) >= 2) && (func_8008F2F8(globalCtx) < 5)) {
+            if (pacifistMode) {
+                gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] =
+                gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[5] = gSaveContext.buttonStatus[6] =
+                gSaveContext.buttonStatus[7] = gSaveContext.buttonStatus[8] = BTN_DISABLED;
+            } else if ((func_8008F2F8(globalCtx) >= 2) && (func_8008F2F8(globalCtx) < 5)) {
                 if (gSaveContext.buttonStatus[0] != BTN_DISABLED) {
                     sp28 = 1;
                 }


### PR DESCRIPTION
Switches to the vanilla game's way of disabling buttons. Makes it so you can equip items while it's on, and changes the opacity of items that are currently unusable.