### PR TITLE
Add: Giving deku shield option. Fix: Giant Lonk

### DIFF
--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -372,6 +372,9 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(const char* effectId, uin
         } else if (strcmp(effectId, "hover_boots") == 0) {
             if (dryRun == 0) CMD_EXECUTE("boots hover");
             return EffectResult::Success;
+        } else if (strcmp(effectId, "give_dekushield") == 0) {
+            if (dryRun == 0) CMD_EXECUTE("givedekushield");
+            return EffectResult::Success;
         } else if (strcmp(effectId, "spawn_wallmaster") == 0 
             || strcmp(effectId, "spawn_arwing") == 0 
             || strcmp(effectId, "spawn_darklink") == 0 

--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -379,7 +379,7 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
         } else if (effectId == "hover_boots") {
             if (dryRun == 0) CMD_EXECUTE("boots hover");
             return EffectResult::Success;
-        } else if (effectId, "give_dekushield") {
+        } else if (effectId == "give_dekushield") {
             if (dryRun == 0) CMD_EXECUTE("givedekushield");
             return EffectResult::Success;
         } else if (effectId == "spawn_wallmaster" 

--- a/soh/soh/Enhancements/crowd-control/soh.cs
+++ b/soh/soh/Enhancements/crowd-control/soh.cs
@@ -68,6 +68,7 @@ public class SoH : SimpleTCPPack
 				new Effect("Burn Link", "burn"),
 				new Effect("Electrocute Link", "electrocute"),
 				new Effect("Iron Boots", "iron_boots") { Duration = 30 },
+				new Effect("Give Deku Shield", "give_dekushield"),
 				new Effect("Spawn Enemy", "spawn_enemy", ItemKind.Folder),
 			};
 			
@@ -83,7 +84,7 @@ public class SoH : SimpleTCPPack
         new ItemType("Rupees", "rupees999", ItemType.Subtype.Slider, "{\"min\":1,\"max\":999}"),
 		new ItemType("Health", "health20", ItemType.Subtype.Slider, "{\"min\":1,\"max\":20}"),
 		new ItemType("Damage/Defense Multiplier", "damdefmulti", ItemType.Subtype.Slider, "{\"min\":1,\"max\":10}"),
-		new ItemType("Knockback Strength", "knockbackstrength", ItemType.Subtype.Slider, "{\"min\":1,\"max\":4}")
+		new ItemType("Knockback Strength", "knockbackstrength", ItemType.Subtype.Slider, "{\"min\":1,\"max\":3}")
     };
 	
 }

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -94,6 +94,18 @@ static bool ActorSpawnHandler(std::shared_ptr<Ship::Console> Console, const std:
     return CMD_SUCCESS;
 }
 
+static bool GiveDekuShieldHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>&) {
+    // Give Deku Shield to the player, and automatically equip it when they're child and have no shield currently equiped.
+    Player* player = GET_PLAYER(gGlobalCtx);
+    Item_Give(gGlobalCtx, ITEM_SHIELD_DEKU);
+    if (LINK_IS_CHILD && player->currentShield == PLAYER_SHIELD_NONE) {
+        player->currentShield = PLAYER_SHIELD_DEKU;
+        Inventory_ChangeEquipment(EQUIP_SHIELD, PLAYER_SHIELD_DEKU);
+    }
+    SohImGui::GetConsole()->SendInfoMessage("[SOH] Gave Deku Shield");
+    return CMD_SUCCESS;
+}
+
 static bool KillPlayerHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>&) {
     gSaveContext.health = 0;
     SohImGui::GetConsole()->SendInfoMessage("[SOH] You've met with a terrible fate, haven't you?");
@@ -991,6 +1003,9 @@ void DebugConsole_Init(void) {
     CMD_REGISTER("bItem", { BHandler, "Set an item to the B button.", {
         { "Item ID", Ship::ArgumentType::NUMBER }
     }});
+
+    CMD_REGISTER("givedekushield", { GiveDekuShieldHandler, "Gives a deku shield and equips it when Link is a child with no shield equiped." });
+
     CMD_REGISTER("spawn", { ActorSpawnHandler, "Spawn an actor.", { { "actor_id", Ship::ArgumentType::NUMBER },
                               { "data", Ship::ArgumentType::NUMBER },
                               { "x", Ship::ArgumentType::PLAYER_POS, true },

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10908,9 +10908,9 @@ void Player_Update(Actor* thisx, GlobalContext* globalCtx) {
     MREG(55) = this->actor.world.rot.y;
 
     if (giantLink == 1) {
-        this->actor.scale.x = 0.025f;
-        this->actor.scale.y = 0.025f;
-        this->actor.scale.z = 0.025f;
+        this->actor.scale.x = 0.02f;
+        this->actor.scale.y = 0.02f;
+        this->actor.scale.z = 0.02f;
     }
 
     if (minishLink == 1) {


### PR DESCRIPTION
Deku shield needs .cs change.

Giant Lonk fix simply brings it in line with the N64 CC size.