### PR TITLE
Fix cucco storm, fix empty heart

### DIFF
--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -419,7 +419,7 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
                 return EffectResult::Failure;
             }
             
-            if (dryRun == 0) CMD_EXECUTE(std::format("damage {}", effectId, value));
+            if (dryRun == 0) CMD_EXECUTE(std::format("{} {}", effectId, value));
             return EffectResult::Success;
         }
     }

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -879,7 +879,7 @@ static bool BurnHandler(std::shared_ptr<Ship::Console> Console, const std::vecto
 static bool CuccoStormHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args) {
     Player* player = GET_PLAYER(gGlobalCtx);
     EnNiw* cucco = (EnNiw*)Actor_Spawn(&gGlobalCtx->actorCtx, gGlobalCtx, ACTOR_EN_NIW, player->actor.world.pos.x,
-                                       player->actor.world.pos.y, player->actor.world.pos.z, 0, 0, 0, 0);
+                                       player->actor.world.pos.y + 2200, player->actor.world.pos.z, 0, 0, 0, 0);
     cucco->actionFunc = func_80AB70A0_nocutscene;
     return CMD_SUCCESS;
 }


### PR DESCRIPTION
Empty heart was sending "damage damage" to the console, is now sending "damage (value)". 

Cucco storm could be canceled by slashing the chicken. Spawning it really high solves this problem. Still triggers the storm just fine even if the cucco gets stuck above link somewhere.